### PR TITLE
Adding Snort Tool to incident_response.json

### DIFF
--- a/data/tools/incident_response.json
+++ b/data/tools/incident_response.json
@@ -137,6 +137,15 @@
       "language": "Go",
       "price": "Free",
       "online": "False"
-    }
+    },
+    {
+      "name": "Snort",
+      "website": "https://www.snort.org/",
+      "source": "https://github.com/snort3/snort3",
+      "description": "An open-source intrusion detection system (IDS) that monitors network traffic for suspicious activities and threats.",
+      "language": "C",
+      "price": "Free",
+      "online": "False"
+    }    
   ]
 }

--- a/data/tools/incident_response.json
+++ b/data/tools/incident_response.json
@@ -82,6 +82,15 @@
       "blackarch": "sigma"
     },
     {
+      "name": "Snort",
+      "website": "https://www.snort.org/",
+      "source": "https://github.com/snort3/snort3",
+      "description": "Intrusion detection system (IDS) that monitors network traffic for suspicious activities and threats",
+      "language": "C",
+      "price": "Free",
+      "online": "False"
+    },    
+    {
       "name": "ThreatHound",
       "source": "https://github.com/MazX0p/ThreatHound",
       "description": "Windows event log file viewer and analyser",
@@ -137,15 +146,6 @@
       "language": "Go",
       "price": "Free",
       "online": "False"
-    },
-    {
-      "name": "Snort",
-      "website": "https://www.snort.org/",
-      "source": "https://github.com/snort3/snort3",
-      "description": "An open-source intrusion detection system (IDS) that monitors network traffic for suspicious activities and threats.",
-      "language": "C",
-      "price": "Free",
-      "online": "False"
-    }    
+    }
   ]
 }


### PR DESCRIPTION
gh-9
feature #9 
Hi I added Snort Tool to Incident_response.json And its not included I check that before adding it here is a screen shot:
![didnt show anything](https://github.com/noraj/rawsec-cybersecurity-inventory/assets/73184801/77ed3494-9b7e-4631-892a-4bf7e7a63501)
Hope you Accept this PR Thanks :)