### PR TITLE
this fixes #54

### DIFF
--- a/pug/index.pug
+++ b/pug/index.pug
@@ -9,8 +9,8 @@ block content
                 .field
                     .control.has-icons-right
                         input.input.is-rounded.is-primary(placeholder="Search" onInput="searchInput(this.value)")
-                        span.icon.is-right
-                            i.fas.fa-search
+                        //- span.icon.is-right
+                        //-    i.fas.fa-search
                 p.is-size-7
                     | Total number of tools and resources indexed: 
                     span.has-text-primary.has-text-weight-bold #{count.total}


### PR DESCRIPTION
- Results are fetched when input.value.length is greater than 2. So search icon is not required.