### PR TITLE
Add cloud-audit to inventory

### DIFF
--- a/data/tools/cloud.json
+++ b/data/tools/cloud.json
@@ -45,6 +45,15 @@
       "online": "False"
     },
     {
+      "name": "cloud-audit",
+      "source": "https://github.com/gebalamariusz/cloud-audit",
+      "description": "Open-source AWS security scanner with 45 CIS benchmark checks across 15 services, copy-paste remediation (CLI + Terraform), and scan diff tracking",
+      "language": "Python",
+      "price": "Free",
+      "online": "False",
+      "keywords": "AWS"
+    },
+    {
       "name": "CloudGPT",
       "source": "https://github.com/ustayready/cloudgpt",
       "description": "Vulnerability scanner for AWS customer managed policies using ChatGPT",

--- a/data/tools/cloud.json
+++ b/data/tools/cloud.json
@@ -47,11 +47,10 @@
     {
       "name": "cloud-audit",
       "source": "https://github.com/gebalamariusz/cloud-audit",
-      "description": "Open-source AWS security scanner with 45 CIS benchmark checks across 15 services, copy-paste remediation (CLI + Terraform), and scan diff tracking",
+      "description": "AWS security scanner with 45 CIS benchmark checks across 15 services, copy-paste remediation (CLI + Terraform), and scan diff tracking",
       "language": "Python",
       "price": "Free",
-      "online": "False",
-      "keywords": "AWS"
+      "online": "False"
     },
     {
       "name": "CloudGPT",


### PR DESCRIPTION
## Summary

- Adds [cloud-audit](https://github.com/gebalamariusz/cloud-audit) to the Cloud tools category
- Open-source AWS security scanner with 45 CIS benchmark checks across 15 services
- Provides copy-paste remediation in both CLI and Terraform format
- Supports scan diff tracking to monitor security posture over time
- Outputs SARIF, HTML, and Markdown reports
- MIT license, Python CLI, installable via PyPI (`pip install cloud-audit`)