### PR TITLE
Add DNSai to OSINT and Reconnaissance tools

### DIFF
--- a/data/tools/osint_and_reconnaissance.json
+++ b/data/tools/osint_and_reconnaissance.json
@@ -152,6 +152,13 @@
       "online": "False"
     },
     {
+      "name": "DNSai",
+      "website": "https://dnsai.com",
+      "description": "DNS intelligence and email security lookups: DNS/WHOIS, SPF analysis with lookup-limit check, DKIM selector discovery, DMARC check, email header analysis, blacklist checks; free web tools and free API tier",
+      "price": "Free",
+      "online": "True"
+    },
+    {
       "name": "DNSDumpster",
       "website": "https://dnsdumpster.com/",
       "description": "Domain research tool that can discover hosts related to a domain",


### PR DESCRIPTION
DNSai adds a few things the existing lookup tools in this section don't cover: DKIM selector discovery (finds a domain's signing keys without knowing selector names), SPF analysis with the 10-DNS-lookup limit check, plain-English interpretation of results aimed at non-experts, and a free API plus MCP server so the same checks run inside AI assistants. All basic lookups are free with no signup or ads.

Disclosure: I'm the founder of DNSai. Happy to adjust wording or placement, and no hard feelings if it's not a fit for the list.
